### PR TITLE
fix(FEV-1079): round startTime of thumb cue-points, fix cue-points endTime

### DIFF
--- a/src/providers/live/live-provider.ts
+++ b/src/providers/live/live-provider.ts
@@ -9,7 +9,7 @@ import {
   SlideViewChangePushNotificationData,
   ThumbPushNotificationData
 } from './push-notifications-provider';
-import {makeAssetUrl} from '../utils';
+import {makeAssetUrl, prepareEndTime, prepareThumbStartTime} from '../utils';
 import Player = KalturaPlayerTypes.Player;
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
@@ -113,7 +113,7 @@ export class LiveProvider extends Provider {
       .map((cue, index) => {
         // fix endTime and replace VTTCue
         if (cue.endTime === Number.MAX_SAFE_INTEGER && index !== cuePoints.length - 1) {
-          const fixedCue = {...cue, endTime: cuePoints[index + 1].startTime};
+          const fixedCue = {...cue, endTime: prepareEndTime(cuePoints[index + 1].startTime)};
           this._player.cuePointManager.addCuePoints([fixedCue]);
           return fixedCue;
         }
@@ -125,7 +125,7 @@ export class LiveProvider extends Provider {
     const startTime = this._player.currentTime - (this._currentTimeLive - newThumb.createdAt);
     const newThumbCue = {
       ...newThumb,
-      startTime: Number(startTime.toFixed(2)),
+      startTime: prepareThumbStartTime(startTime),
       endTime: Number.MAX_SAFE_INTEGER,
       assetUrl: makeAssetUrl(this._player.config.provider.env?.serviceUrl, newThumb.assetId, this._player.config.session?.ks)
     };

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -18,5 +18,5 @@ export function prepareEndTime(endTime: number) {
 }
 
 export function prepareThumbStartTime(startTime: number) {
-  return Math.round(startTime / 1000);
+  return Math.round(startTime);
 }

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_SERVICE_URL = '//cdnapisec.kaltura.com/api_v3';
+export const END_TIME_DELTA = 0.01;
 
 export function isEmptyObject(obj: Record<string, any>) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
@@ -10,4 +11,12 @@ export function getDomainFromUrl(url: string) {
 
 export function makeAssetUrl(serviceUrl: string = DEFAULT_SERVICE_URL, assetId: string, ks: string = '') {
   return `${serviceUrl}/index.php/service/thumbAsset/action/serve/thumbAssetId/${assetId}/ks/${ks}`;
+}
+
+export function prepareEndTime(endTime: number) {
+  return endTime - END_TIME_DELTA;
+}
+
+export function prepareThumbStartTime(startTime: number) {
+  return Math.round(startTime / 1000);
 }

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -5,7 +5,7 @@ import {KalturaCuePointType, KalturaThumbCuePointSubType, CuepointTypeMap} from 
 import Player = KalturaPlayerTypes.Player;
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
-import {makeAssetUrl} from '../utils';
+import {makeAssetUrl, prepareEndTime, prepareThumbStartTime} from '../utils';
 import {ViewChangeLoader} from './view-change-loader';
 import {KalturaCodeCuePoint} from './response-types/kaltura-code-cue-point';
 
@@ -60,10 +60,10 @@ export class VodProvider extends Provider {
 
   private _fixCuePointsEndTime<T extends {startTime: number; endTime: number}>(cuePoints: T[]) {
     return cuePoints.map((cuePoint: any, index: number) => {
-      if (!cuePoint.endTime) {
+      if (cuePoint.endTime === Number.MAX_SAFE_INTEGER && index !== cuePoints.length - 1) {
         return {
           ...cuePoint,
-          endTime: index === cuePoints.length - 1 ? Number.MAX_SAFE_INTEGER : cuePoints[index + 1].startTime
+          endTime: prepareEndTime(cuePoints[index + 1].startTime)
         };
       }
       return cuePoint;
@@ -118,8 +118,8 @@ export class VodProvider extends Provider {
           assetUrl: makeAssetUrl(this._player.config.provider.env?.serviceUrl, thumbCuePoint.assetId, this._player.config.session.ks),
           id: thumbCuePoint.id,
           cuePointType: thumbCuePoint.cuePointType,
-          startTime: thumbCuePoint.startTime / 1000,
-          endTime: 0
+          startTime: prepareThumbStartTime(thumbCuePoint.startTime),
+          endTime: Number.MAX_SAFE_INTEGER
         };
       });
     };

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -118,7 +118,7 @@ export class VodProvider extends Provider {
           assetUrl: makeAssetUrl(this._player.config.provider.env?.serviceUrl, thumbCuePoint.assetId, this._player.config.session.ks),
           id: thumbCuePoint.id,
           cuePointType: thumbCuePoint.cuePointType,
-          startTime: prepareThumbStartTime(thumbCuePoint.startTime),
+          startTime: prepareThumbStartTime(thumbCuePoint.startTime / 1000),
           endTime: Number.MAX_SAFE_INTEGER
         };
       });


### PR DESCRIPTION
1) round start-time of thumb cue-points to the nearest second;
2) uses 0.01s as a time delta between end-time of current cue-point and start-time of next cue-point (prevent 2 active cue-points on the same time)