### PR TITLE
fix(FEV-1122): Slides switching breaks the current layout and changes it back to the default one

### DIFF
--- a/src/providers/live/live-provider.ts
+++ b/src/providers/live/live-provider.ts
@@ -9,7 +9,7 @@ import {
   SlideViewChangePushNotificationData,
   ThumbPushNotificationData
 } from './push-notifications-provider';
-import {makeAssetUrl, prepareEndTime} from '../utils';
+import {makeAssetUrl} from '../utils';
 import Player = KalturaPlayerTypes.Player;
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
@@ -113,7 +113,7 @@ export class LiveProvider extends Provider {
       .map((cue, index) => {
         // fix endTime and replace VTTCue
         if (cue.endTime === Number.MAX_SAFE_INTEGER && index !== cuePoints.length - 1) {
-          const fixedCue = {...cue, endTime: prepareEndTime(cuePoints[index + 1].startTime)};
+          const fixedCue = {...cue, endTime: cuePoints[index + 1].startTime};
           this._player.cuePointManager.addCuePoints([fixedCue]);
           return fixedCue;
         }

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,5 +1,4 @@
 export const DEFAULT_SERVICE_URL = '//cdnapisec.kaltura.com/api_v3';
-export const END_TIME_DELTA = 0.01;
 
 export function isEmptyObject(obj: Record<string, any>) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
@@ -11,8 +10,4 @@ export function getDomainFromUrl(url: string) {
 
 export function makeAssetUrl(serviceUrl: string = DEFAULT_SERVICE_URL, assetId: string, ks: string = '') {
   return `${serviceUrl}/index.php/service/thumbAsset/action/serve/thumbAssetId/${assetId}/ks/${ks}`;
-}
-
-export function prepareEndTime(endTime: number) {
-  return endTime - END_TIME_DELTA;
 }

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -5,7 +5,7 @@ import {KalturaCuePointType, KalturaThumbCuePointSubType, CuepointTypeMap} from 
 import Player = KalturaPlayerTypes.Player;
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
-import {makeAssetUrl, prepareEndTime} from '../utils';
+import {makeAssetUrl} from '../utils';
 import {ViewChangeLoader} from './view-change-loader';
 import {KalturaCodeCuePoint} from './response-types/kaltura-code-cue-point';
 
@@ -63,7 +63,7 @@ export class VodProvider extends Provider {
       if (cuePoint.endTime === Number.MAX_SAFE_INTEGER && index !== cuePoints.length - 1) {
         return {
           ...cuePoint,
-          endTime: prepareEndTime(cuePoints[index + 1].startTime)
+          endTime: cuePoints[index + 1].startTime
         };
       }
       return cuePoint;


### PR DESCRIPTION
if we use delta 0.01s between `endTime` and `startTime` sometimes `TIMED_METADATA` event fires with empty array of active cue-points. It makes issue when Dual-screen plugin removes active layout. As a solution - reverse array of active cue-points and makes search from end to start in order pick-up the most relevant (latest) active cue-point