### PR TITLE
fix(FEV-1249): Kaltura CuePoints loads thumb assets always with KS

### DIFF
--- a/src/cuepoint-service.ts
+++ b/src/cuepoint-service.ts
@@ -3,7 +3,7 @@ import {Provider} from './providers/provider';
 import {VodProvider} from './providers/vod/vod-provider';
 import {LiveProvider} from './providers/live/live-provider';
 import {KalturaCuePoint} from './providers/vod/response-types';
-import {CuepointTypeMap, KalturaCuePointType, KalturaThumbCuePointSubType} from './types';
+import {CuepointTypeMap, KalturaCuePointType, KalturaThumbCuePointSubType, CuepointsConfig} from './types';
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
 
@@ -27,7 +27,7 @@ export class CuepointService {
     return KalturaCuePoint.KalturaCuePointType;
   }
 
-  constructor(player: Player, eventManager: EventManager, logger: any) {
+  constructor(player: Player, eventManager: EventManager, logger: any, private _config: CuepointsConfig) {
     this._logger = logger;
     this._player = player;
     this._eventManager = eventManager;
@@ -60,9 +60,9 @@ export class CuepointService {
     }
 
     if (this._player.isLive()) {
-      this._provider = new LiveProvider(this._player, this._eventManager, this._logger, this._types);
+      this._provider = new LiveProvider(this._player, this._eventManager, this._logger, this._types, this._config);
     } else {
-      this._provider = new VodProvider(this._player, this._eventManager, this._logger, this._types);
+      this._provider = new VodProvider(this._player, this._eventManager, this._logger, this._types, this._config);
     }
   }
 

--- a/src/cuepoints.ts
+++ b/src/cuepoints.ts
@@ -1,4 +1,5 @@
 import {CuepointService} from './cuepoint-service';
+import {CuepointsConfig} from './types';
 import Player = KalturaPlayerTypes.Player;
 
 export class Cuepoints extends KalturaPlayer.core.BasePlugin {
@@ -7,12 +8,14 @@ export class Cuepoints extends KalturaPlayer.core.BasePlugin {
    * The default configuration of the plugin.
    * @static
    */
-  static defaultConfig = {};
+  static defaultConfig: CuepointsConfig = {
+    loadThumbnailWithKs: false
+  };
 
-  constructor(name: string, player: Player) {
-    super(name, player);
+  constructor(name: string, player: Player, config: CuepointsConfig) {
+    super(name, player, config);
 
-    this._cuePointService = new CuepointService(player, this.eventManager, this.logger);
+    this._cuePointService = new CuepointService(player, this.eventManager, this.logger, this.config);
     player.registerService('kalturaCuepoints', this._cuePointService);
   }
 

--- a/src/providers/live/live-provider.ts
+++ b/src/providers/live/live-provider.ts
@@ -1,5 +1,5 @@
 import {Provider} from '../provider';
-import {KalturaCuePointType, CuepointTypeMap} from '../../types';
+import {KalturaCuePointType, CuepointTypeMap, CuepointsConfig} from '../../types';
 import {
   PushNotificationPrivider,
   PushNotificationEventTypes,
@@ -26,7 +26,7 @@ export class LiveProvider extends Provider {
   private _currentTimeLiveResolvePromise = () => {};
   private _currentTimeLivePromise: Promise<void>;
 
-  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap) {
+  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap, private _config: CuepointsConfig) {
     super(player, eventManager, logger, types);
     this._pushNotification = new PushNotificationPrivider(this._player, this._logger);
     this._currentTimeLivePromise = this._makeCurrentTimeLiveReadyPromise();
@@ -130,7 +130,11 @@ export class LiveProvider extends Provider {
     const newThumbCue = {
       ...newThumb,
       ...this._makeCuePointStartEndTime(newThumb.createdAt),
-      assetUrl: makeAssetUrl(this._player.provider.env.serviceUrl, newThumb.assetId, this._player.config.session?.ks)
+      assetUrl: makeAssetUrl(
+        this._player.provider.env.serviceUrl,
+        newThumb.assetId,
+        this._config.loadThumbnailWithKs ? this._player.config.session.ks : ''
+      )
     };
     this._thumbCuePoints.push(newThumbCue);
     this._thumbCuePoints = this._fixCuePointEndTime(this._thumbCuePoints);

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -7,7 +7,7 @@ export function getDomainFromUrl(url: string) {
 }
 
 export function makeAssetUrl(serviceUrl: string, assetId: string, ks: string = '') {
-  return `${serviceUrl}/index.php/service/thumbAsset/action/serve/thumbAssetId/${assetId}/ks/${ks}`;
+  return `${serviceUrl}/index.php/service/thumbAsset/action/serve/thumbAssetId/${assetId}${ks ? `/ks/${ks}` : ''}`;
 }
 
 export function sortArrayBy<T>(cuePoints: T[], primarySortKey: string, secondarySortKey?: string) {

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -1,7 +1,7 @@
 import {Provider, ProviderRequest} from '../provider';
 import {ThumbLoader} from './thumb-loader';
 import {KalturaQuizQuestionCuePoint, KalturaThumbCuePoint, KalturaCodeCuePoint} from './response-types';
-import {KalturaCuePointType, KalturaThumbCuePointSubType, CuepointTypeMap} from '../../types';
+import {KalturaCuePointType, KalturaThumbCuePointSubType, CuepointTypeMap, CuepointsConfig} from '../../types';
 import Player = KalturaPlayerTypes.Player;
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
@@ -10,7 +10,7 @@ import {ViewChangeLoader} from './view-change-loader';
 import {QuizQuestionLoader} from './quiz-question-loader';
 
 export class VodProvider extends Provider {
-  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap) {
+  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap, private _config: CuepointsConfig) {
     super(player, eventManager, logger, types);
     this._fetchVodData();
   }
@@ -127,7 +127,11 @@ export class VodProvider extends Provider {
     const createCuePointList = (thumbCuePoints: Array<KalturaThumbCuePoint>) => {
       return thumbCuePoints.map((thumbCuePoint: KalturaThumbCuePoint) => {
         return {
-          assetUrl: makeAssetUrl(this._player.provider.env.serviceUrl, thumbCuePoint.assetId, this._player.config.session.ks),
+          assetUrl: makeAssetUrl(
+            this._player.provider.env.serviceUrl,
+            thumbCuePoint.assetId,
+            this._config.loadThumbnailWithKs ? this._player.config.session.ks : ''
+          ),
           id: thumbCuePoint.id,
           cuePointType: thumbCuePoint.cuePointType,
           startTime: thumbCuePoint.startTime / 1000,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,6 @@ export enum KalturaCuePointType {
   // HOTSPOT = 'hotspot',
   // CHAPTER = 'chapter'
 }
+export interface CuepointsConfig {
+  loadThumbnailWithKs: boolean;
+}


### PR DESCRIPTION
use KS for thumbnails API only if configured "loadThumbnailWithKs" property