### PR TITLE
fix: regex fix for getting the correct asset id

### DIFF
--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -128,7 +128,7 @@ export class VodProvider extends Provider {
     if (this._fetchedCaptionKeys.includes(captionKey) || this._fetchingCaptionKey === captionKey) {
       return; // prevent fetch captons if data already exist or fetching now
     }
-    const match = captonSource.url.match('/captionAssetId/(.*?)/');
+    const match = captonSource.url.match('/captionAssetId/(.*?)(/|$)');
     if (!match || !match[1]) {
       return; // captionAssetId not found;
     }


### PR DESCRIPTION
Issue found during testing transcript plugin: for anonymous users captionAsset ID is latest parameter in URL. New Regex checks if captionAsset ID is latest parameter in URL, otherwise find next "/" character 