### PR TITLE
fix(FEV-1415): Hotspots doesn't disappear at the correct time that configured and they remain displayed until the end of the video.

### DIFF
--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -329,7 +329,7 @@ export class VodProvider extends Provider {
           text: hotspotCuePoint.text,
           partnerData: hotspotCuePoint.partnerData,
           startTime: hotspotCuePoint.startTime / 1000,
-          endTime: hotspotCuePoint.endTime || Number.MAX_SAFE_INTEGER,
+          endTime: hotspotCuePoint.endTime ? hotspotCuePoint.endTime / 1000 : Number.MAX_SAFE_INTEGER,
           tags: hotspotCuePoint.tags
         };
       });


### PR DESCRIPTION
fix hotspots cues end-time