### PR TITLE
fix(FEV-1629): incorrect slide layout appear after live clipping

### DIFF
--- a/src/providers/vod/response-types/kaltura-code-cue-point.ts
+++ b/src/providers/vod/response-types/kaltura-code-cue-point.ts
@@ -24,11 +24,18 @@ export class KalturaCodeCuePoint extends KalturaCuePoint {
    */
   duration: number;
 
+  /**
+   * @member - The cue point tags
+   * @type {string}
+   */
+  tags: string = '';
+
   constructor(codeCuePoint: any) {
     super(codeCuePoint);
     this.code = codeCuePoint.code;
     this.description = codeCuePoint.description;
     this.endTime = codeCuePoint.endTime;
     this.duration = codeCuePoint.duration;
+    this.tags = codeCuePoint.tags;
   }
 }

--- a/src/providers/vod/view-change-loader.ts
+++ b/src/providers/vod/view-change-loader.ts
@@ -35,7 +35,7 @@ export class ViewChangeLoader implements ILoader {
       },
       responseProfile: {
         type: INCLUDE_FIELDS,
-        fields: 'id, startTime, endTime, partnerData, cuePointType'
+        fields: 'id, startTime, endTime, partnerData, cuePointType, tags'
       }
     };
     this.requests.push(request);

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -188,7 +188,8 @@ export class VodProvider extends Provider {
           startTime: viewChangeCuePoint.startTime / 1000,
           endTime: viewChangeCuePoint.endTime || Number.MAX_SAFE_INTEGER,
           cuePointType: viewChangeCuePoint.cuePointType,
-          partnerData: viewChangeCuePoint.partnerData
+          partnerData: viewChangeCuePoint.partnerData,
+          tags: viewChangeCuePoint.tags
         };
       });
     }


### PR DESCRIPTION
**the issue:**
when broadcasting slides using the webcast app, changing the layout in webcast app to side by side and creating a vod (clipping the live entry)- the layout of the vod is showing in pip instead of sbs.

**root cause:**
on dualscreen side we check for `tags='change-view-mode'`, however, we don't have tags as an attribute on the cuepoint object, so it always doesn't exist.

**solution:**
add tags attribute to the code cuepoint object.

Solves [FEV-1629](https://kaltura.atlassian.net/browse/FEV-1629)

[FEV-1629]: https://kaltura.atlassian.net/browse/FEV-1629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ