### PR TITLE
fix(FEC-12948): navigation plugin renders thumbnails for chapters with default thumbnail

### DIFF
--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -226,11 +226,11 @@ export class VodProvider extends Provider {
     const replaceAssetUrl = (baseThumbAssetUrl: string) => (thumbCuePoint: KalturaThumbCuePoint) => {
       return makeAssetUrl(baseThumbAssetUrl, thumbCuePoint.assetId);
     };
-    const generageAssetUrl = (thumbCuePoint: KalturaThumbCuePoint) => {
+    const generateAssetUrl = (thumbCuePoint: KalturaThumbCuePoint) => {
       const {provider} = this._player.config;
       return generateThumb(provider?.env?.serviceUrl, provider?.partnerId, this._player.sources.id, thumbCuePoint.startTime, provider?.ks);
     };
-    const addCuePoins = (thumbCuePoints: Array<KalturaThumbCuePoint>, assetUrlCreator: (thumbCuePoint: KalturaThumbCuePoint) => string) => {
+    const addCuePoints = (thumbCuePoints: Array<KalturaThumbCuePoint>, assetUrlCreator: (thumbCuePoint: KalturaThumbCuePoint) => string) => {
       let cuePoints = thumbCuePoints.map((thumbCuePoint: KalturaThumbCuePoint) => {
         return {
           assetUrl: assetUrlCreator(thumbCuePoint),
@@ -240,7 +240,8 @@ export class VodProvider extends Provider {
           description: thumbCuePoint.description,
           subType: thumbCuePoint.subType,
           startTime: thumbCuePoint.startTime / 1000,
-          endTime: Number.MAX_SAFE_INTEGER
+          endTime: Number.MAX_SAFE_INTEGER,
+          isDefaultThumb: !thumbCuePoint.assetId
         };
       });
       cuePoints = sortArrayBy(cuePoints, 'startTime');
@@ -279,7 +280,7 @@ export class VodProvider extends Provider {
               const thumbAssetUrlLoader: ThumbUrlLoader = data.get(ThumbUrlLoader.id);
               const baseThumbAssetUrl: string = thumbAssetUrlLoader?.response;
               if (baseThumbAssetUrl && slideCuePoints.length) {
-                addCuePoins(slideCuePoints, replaceAssetUrl(baseThumbAssetUrl));
+                addCuePoints(slideCuePoints, replaceAssetUrl(baseThumbAssetUrl));
               }
               if (baseThumbAssetUrl && chapterCuePoints.length) {
                 // if chapters has assetId - make assetUrl from baseAssetUrl otherwise - generate from media by startTime
@@ -289,9 +290,9 @@ export class VodProvider extends Provider {
                     return replaceAssetUrl(baseThumbAssetUrl)(thumbCuePoint);
                   }
                   // AssetUrl gonna be made by BE service (snapshot from current media by time)
-                  return generageAssetUrl(thumbCuePoint);
+                  return generateAssetUrl(thumbCuePoint);
                 };
-                addCuePoins(chapterCuePoints, chapterAssetUrlCreator);
+                addCuePoints(chapterCuePoints, chapterAssetUrlCreator);
               }
             }
           })
@@ -299,7 +300,7 @@ export class VodProvider extends Provider {
             this._logger.warn('ThumbUrlLoader doRequest was rejected');
           });
       } else if (chapterCuePoints.length) {
-        addCuePoins(chapterCuePoints, generageAssetUrl);
+        addCuePoints(chapterCuePoints, generateAssetUrl);
       }
     }
   }


### PR DESCRIPTION
**the issue:**
navigation plugin renders thumbnails for chapters that their thumbnails were created automatically and were not initially uploaded by the user.
this is not matching the new design; navigation plugin should not render default thumbnails.

**solution:**
adding a new flag named `isDefaultThumb` which indicates whether a thumbnail was uploaded by the user or was created automatically, according to the assetId;
an undefined assetId means that the thumbnail was created auto, while an assetId with a value is a thumbnail that was uploaded.

- also fixed some typos

**related PR-** https://github.com/kaltura/playkit-js-navigation/pull/323

Solves [FEC-12948](https://kaltura.atlassian.net/browse/FEC-12948)

[FEC-12948]: https://kaltura.atlassian.net/browse/FEC-12948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ