### PR TITLE
fix(FEC-13533): filter and move cue points if video was clipped

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -24,6 +24,9 @@ export class Provider {
   }
 
   protected _addCuePointToPlayer(cuePoints: any[]) {
+    if (!cuePoints.length) {
+      return;
+    }
     const playerCuePoints: CuePoint[] = cuePoints.map(cuePoint => {
       const {startTime, endTime, id, ...metadata} = cuePoint;
       return {startTime, endTime, id, metadata};


### PR DESCRIPTION
**the issue:**
if using the clip option via share plugin while the original entry has cue points (thumbnails, hotspots, etc...), the clipped video is showing cue points that shouldn't be shown in the new range.

**solution:**
1. first, filter out cue points that are out of the new clipped video range
2. second, fix the start and end times of the cue points according to the new video clip

**Examples:**
1. if there is a cue point on the original entry at 00:05 and we clipped the video to start from 00:10 -> this cue point should not appear at all on the new clipped video.
2. if there is a cue point on the original entry at 00:05 and we clipped the video to start from 00:02 -> this cue point should appear on the new clipped video, at 00:03 (its end time should be moved as well).

Solves [FEC-13533 ](https://kaltura.atlassian.net/browse/FEC-13533)