### PR TITLE
fix(FEC-13628): fix filtering cuepoints for clipped video

### DIFF
--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -381,7 +381,7 @@ export class VodProvider extends Provider {
   }
 
   private _filterCuePointsOutOfVideoRange(cuePoints: any[], seekFrom: number, clipTo: number): any[] {
-    return cuePoints.filter((cp: any) => cp.startTime >= seekFrom && (cp.endTime <= clipTo || cp.endTime === Number.MAX_SAFE_INTEGER));
+    return cuePoints.filter((cp: any) => cp.startTime >= seekFrom && cp.startTime < clipTo);
   }
 
   public destroy(): void {

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -359,10 +359,10 @@ export class VodProvider extends Provider {
     // TODO: add seekFrom and clipTo to player-config.d.ts file in kaltura-player
     // @ts-ignore
     const {seekFrom, clipTo} = this._player.sources;
-    if (cuePoints.length && typeof seekFrom === 'number' && clipTo) {
-      // video was clipped- the original cue-points times may not fit the new video
+    if (cuePoints.length && (seekFrom || clipTo)) {
+      // video was clipped - the original cue-points times may not fit the new video
       // filter cue-points that are out of the clipped video range
-      const filteredCuePoints = this._filterCuePointsOutOfVideoRange(cuePoints, seekFrom, clipTo);
+      const filteredCuePoints = this._filterCuePointsOutOfVideoRange(cuePoints, seekFrom || 0, clipTo);
       // move the cue-points by adjusting their start and end times
       this._shiftCuePoints(filteredCuePoints, seekFrom);
       return filteredCuePoints;
@@ -380,8 +380,8 @@ export class VodProvider extends Provider {
     });
   }
 
-  private _filterCuePointsOutOfVideoRange(cuePoints: any[], seekFrom: number, clipTo: number): any[] {
-    return cuePoints.filter((cp: any) => cp.startTime >= seekFrom && cp.startTime < clipTo);
+  private _filterCuePointsOutOfVideoRange(cuePoints: any[], seekFrom: number, clipTo: number | undefined): any[] {
+    return cuePoints.filter((cp: any) => cp.startTime >= seekFrom && (!clipTo || cp.startTime < clipTo));
   }
 
   public destroy(): void {

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -364,7 +364,7 @@ export class VodProvider extends Provider {
       // filter cue-points that are out of the clipped video range
       const filteredCuePoints = this._filterCuePointsOutOfVideoRange(cuePoints, seekFrom || 0, clipTo);
       // move the cue-points by adjusting their start and end times
-      this._shiftCuePoints(filteredCuePoints, seekFrom);
+      this._shiftCuePoints(filteredCuePoints, seekFrom || 0);
       return filteredCuePoints;
     }
     return cuePoints;


### PR DESCRIPTION
- **bugfix**

**the issue:**
- the last chapter/slide cuepoint, in an original video, is shown in navigation panel for clipped video, even though its `startTime` is greater than `clipTo`.
- hotspot cuepoints are not shown in navigation panel when their `endTime` is greater than `clipTo`.
- `clipTo` is optional - should support this use-case as well.

**Solution:**
fix the logic for filtering out cuepoints on clipped video- cuepoint should be shown in a clipped video if its `startTime` is greater or equal to `seekFrom` and less than `clipTo`.

Solves [FEC-13628](https://kaltura.atlassian.net/browse/FEC-13628)

[FEC-13628]: https://kaltura.atlassian.net/browse/FEC-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ