### PR TITLE
fix(FEC-13625): filter captions cuepoints for clipped video

### DIFF
--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -166,6 +166,7 @@ export class VodProvider extends Provider {
             });
             // filter empty captions
             cuePoints = cuePoints.filter(cue => cue.text);
+            cuePoints = this._filterAndShiftCuePoints(cuePoints);
             this._addCuePointToPlayer(cuePoints);
             // mark captions as fetched
             this._fetchedCaptionKeys.push(captionKey);
@@ -372,10 +373,9 @@ export class VodProvider extends Provider {
 
   private _shiftCuePoints(cuePoints: any[], seekFrom: number): void {
     cuePoints.forEach((cp: any) => {
-      const offset = cp.startTime - seekFrom;
-      cp.startTime = offset;
+      cp.startTime = cp.startTime - seekFrom;
       if (cp.endTime !== Number.MAX_SAFE_INTEGER) {
-        cp.endTime = cp.endTime - offset;
+        cp.endTime = cp.endTime - seekFrom;
       }
     });
   }


### PR DESCRIPTION
### Description of Changes:
- add filtering to captions, when video is clipped
- fix calculation for `startTime` and `endTime`

Solves [FEC-13625](https://kaltura.atlassian.net/browse/FEC-13625)

[FEC-13625]: https://kaltura.atlassian.net/browse/FEC-13625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ