### PR TITLE
feat(FEC-13561): Hotspots for simulive

### DIFF
--- a/src/providers/live/live-provider.ts
+++ b/src/providers/live/live-provider.ts
@@ -355,13 +355,13 @@ export class LiveProvider extends Provider {
   }
 
   _getSimuliveCuesOffset(clipTimestamp: number): number | null {
+    //@ts-ignore
+    const startTimeOfDvrWindow = this._player.getStartTimeOfDvrWindow();
     if (this._player.isOnLiveEdge()) {
       const timeFromClipStart = Math.floor(Date.now() - clipTimestamp) / 1000;
       const currentTime = Math.floor(this._player.currentTime);
-      return currentTime - timeFromClipStart + 20;
+      return startTimeOfDvrWindow + currentTime - timeFromClipStart + 20;
     } else {
-      //@ts-ignore
-      const startTimeOfDvrWindow = this._player.getStartTimeOfDvrWindow();
       //@ts-ignore
       const id3Track = [...this._player.getVideoElement().textTracks].find(t => t.label === 'id3');
 


### PR DESCRIPTION
Add hotspots for simulive:
If live stream contains an id3 metadata track, check if it contains simulive timestamps and make a calculation to position hotspots relative to the start of the simulive.

Related PR: https://github.com/kaltura/playkit-js-hotspots/pull/316

Resolves FEC-13561