### PR TITLE
feat(FEC-13492): add support for prevent seek

### DIFF
--- a/src/cuepoint-service.ts
+++ b/src/cuepoint-service.ts
@@ -14,6 +14,7 @@ export class CuepointService {
   private _eventManager: EventManager;
   private _logger: Logger;
   private _mediaLoaded: boolean = false;
+  private _isPreventSeekActive: boolean = false;
 
   public get CuepointType() {
     return KalturaCuePointType;
@@ -44,6 +45,10 @@ export class CuepointService {
     });
   }
 
+  public setIsPreventSeekActive = (isPreventSeekActive: boolean): void => {
+    this._isPreventSeekActive = isPreventSeekActive;
+  };
+
   public registerTypes(types: KalturaCuePointType[]) {
     if (this._mediaLoaded) {
       this._logger.warn('Cue point registration should occur on loadMedia (or before)');
@@ -70,7 +75,7 @@ export class CuepointService {
     if (this._player.isLive()) {
       this._provider = new LiveProvider(this._player, this._eventManager, this._logger, this._types);
     } else {
-      this._provider = new VodProvider(this._player, this._eventManager, this._logger, this._types);
+      this._provider = new VodProvider(this._player, this._eventManager, this._logger, this._types, this._isPreventSeekActive);
     }
   }
 

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -20,17 +20,16 @@ export class VodProvider extends Provider {
   private _lastTimeUpdated: number = 0;
   private _isPreventSeekActive: boolean;
 
-  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap) {
+  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap, isPreventSeekActive: boolean) {
     super(player, eventManager, logger, types);
-    // @ts-ignore
-    this._isPreventSeekActive = player.preventSeekOptions.isActive;
+    this._isPreventSeekActive = isPreventSeekActive;
     this._addListeners();
     this._fetchVodData();
   }
 
   private _addListeners() {
     if (this._types.has(KalturaCuePointType.CAPTION)) {
-      // handle non external text tracks (on init)
+      // handle non-external text tracks (on init)
       this._eventManager.listenOnce(this._player, this._player.Event.TEXT_TRACK_ADDED, this._handleLanguageChange);
       // handle change of caption track
       this._eventManager.listen(this._player, this._player.Event.TEXT_TRACK_CHANGED, this._handleLanguageChange);


### PR DESCRIPTION
add support for prevent seek.

if `preventSeek` is active:
- do not fire all cuepoints at start, but keep them in a data structure
- add a listener to `TIME_UPDATE` event
- add to the player relevant cue points - where their `startTime` is <= `currentTime`

dependent on PR: https://github.com/kaltura/kaltura-player-js/pull/747

Solves FEC-13492