### PR TITLE
fix(FEC-13781): use new isPreventSeek redux state

### DIFF
--- a/src/cuepoint-service.ts
+++ b/src/cuepoint-service.ts
@@ -14,7 +14,6 @@ export class CuepointService {
   private _eventManager: EventManager;
   private _logger: Logger;
   private _mediaLoaded: boolean = false;
-  private _isPreventSeekActive: boolean = false;
 
   public get CuepointType() {
     return KalturaCuePointType;
@@ -45,10 +44,6 @@ export class CuepointService {
     });
   }
 
-  public setIsPreventSeekActive = (isPreventSeekActive: boolean): void => {
-    this._isPreventSeekActive = isPreventSeekActive;
-  };
-
   public registerTypes(types: KalturaCuePointType[]) {
     if (this._mediaLoaded) {
       this._logger.warn('Cue point registration should occur on loadMedia (or before)');
@@ -75,7 +70,7 @@ export class CuepointService {
     if (this._player.isLive()) {
       this._provider = new LiveProvider(this._player, this._eventManager, this._logger, this._types);
     } else {
-      this._provider = new VodProvider(this._player, this._eventManager, this._logger, this._types, this._isPreventSeekActive);
+      this._provider = new VodProvider(this._player, this._eventManager, this._logger, this._types);
     }
   }
 
@@ -83,6 +78,5 @@ export class CuepointService {
     this._mediaLoaded = false;
     this._types.clear();
     this._provider?.destroy();
-    this._isPreventSeekActive = false;
   }
 }

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -20,9 +20,9 @@ export class VodProvider extends Provider {
   private _lastTimeUpdated: number = 0;
   private _isPreventSeekActive: boolean;
 
-  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap, isPreventSeekActive: boolean) {
+  constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap) {
     super(player, eventManager, logger, types);
-    this._isPreventSeekActive = isPreventSeekActive;
+    this._isPreventSeekActive = player.ui.store.getState().seekbar.isPreventSeek;
     this._addListeners();
     this._fetchVodData();
   }
@@ -350,7 +350,7 @@ export class VodProvider extends Provider {
       let cuePoints = createCuePointList(quizQuestionCuePoints);
       cuePoints = this._filterAndShiftCuePoints(cuePoints);
       cuePoints = sortArrayBy(cuePoints, 'startTime', 'createdAt');
-      this._addCuePointsData(cuePoints);
+      this._addCuePointToPlayer(cuePoints);
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

**the issue:**
When `PreventFwdSeek` set to true, "Quiz completed" toast is display although not all of the question were answered.

**root cause:**
since cuePoint service is delaying the cuePoints in case `preventSeek` plugin feature is active, ivq is not getting any data so it thinks the quiz is completed.

**solution:**
- use new `isPreventSeek` redux state
- for quiz cuePoints, send the cue points immediately

Solves [FEC-13781](https://kaltura.atlassian.net/browse/FEC-13781)

[FEC-13781]: https://kaltura.atlassian.net/browse/FEC-13781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ