### PR TITLE
fix(FEC-13775): transcript shows only current caption line

### DIFF
--- a/src/cuepoint-service.ts
+++ b/src/cuepoint-service.ts
@@ -76,7 +76,7 @@ export class CuepointService {
 
   public reset(): void {
     this._mediaLoaded = false;
-    this._types.clear();
     this._provider?.destroy();
+    this._types.clear();
   }
 }

--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -53,19 +53,17 @@ export class VodProvider extends Provider {
   private _pushCuePointsToPlayer(): void {
     for (const pendingCuePoints of this._pendingCuePointsData) {
       let cpToAdd: any[] = [];
-      let amountToDelete = 0;
       for (let index = 0; index < pendingCuePoints.length; index++) {
         const cp = pendingCuePoints[index];
         if (Math.floor(cp.startTime) <= this._player.currentTime) {
           cpToAdd.push(cp);
-          amountToDelete++;
         } else {
           // next cue points will have greater start time, no need to continue the loop
           break;
         }
       }
       // remove cue points from pending array, that are going to be pushed
-      pendingCuePoints.splice(0, amountToDelete);
+      pendingCuePoints.splice(0, cpToAdd.length);
       this._addCuePointToPlayer(cpToAdd);
     }
   }
@@ -185,8 +183,6 @@ export class VodProvider extends Provider {
   private _loadCaptions = (captonSource: KalturaCaptionSource) => {
     const captionKey = `${captonSource.language}-${captonSource.label}`;
     if (this._fetchedCaptionKeys.includes(captionKey) || this._fetchingCaptionKey === captionKey) {
-      // after captions were switched, might need to manually push cue points
-      this._maybeForcePushingCuePoints();
       return; // prevent fetch captons if data already exist or fetching now
     }
     const match = captonSource.url.match('/captionAssetId/(.*?)(/|$)');


### PR DESCRIPTION
**the issue:**
when `preventSeek` is active, `onTimeUpdate` callback was pushing only new data. As a result, in transcript only the current active caption line was displayed.

**solution:**
- add the cuePoints to a pending list
- listen to `TIME_UPDATE` event and in callback: push only new cue points to player and remove them from the pending list
- handle cases where the player is paused and need to switch captions, as we rely on `timeUpdate` event
- make the filter and push cuePoints at least every 400 ms, to not overload

**related PR:** https://github.com/kaltura/playkit-js-transcript/pull/183

Solves FEC-13775