### PR TITLE
fix(SUP-43350): Webcasting Q&A (Announcements Only) not working

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -3,7 +3,7 @@ import {CuePointManager} from '../cuepoint-manager';
 import Player = KalturaPlayerTypes.Player;
 import Logger = KalturaPlayerTypes.Logger;
 import EventManager = KalturaPlayerTypes.EventManager;
-import {KalturaHotspotCuePoint, KalturaThumbCuePoint} from './vod/response-types';
+import {KalturaCuePoint, KalturaHotspotCuePoint, KalturaThumbCuePoint} from './vod/response-types';
 import {HotspotLoader, ThumbLoader, ThumbUrlLoader} from './common/';
 import {makeAssetUrl, generateThumb, sortArrayBy} from './utils';
 import {DataAggregator} from './data-aggregator';
@@ -60,6 +60,9 @@ export class Provider {
       this.cuePointManager.addCuePoints(playerCuePoints);
     } else if (useDataAggregator) {
       playerCuePoints.forEach(cuePoint => {
+        if (cuePoint.metadata.cuePointType === KalturaCuePoint.KalturaCuePointType.CODE){
+          this._player.cuePointManager.addCuePoints(playerCuePoints);
+        }
         this._dataAggregator!.addData(cuePoint);
       });
     } else if (usePendingQueManager) {


### PR DESCRIPTION
**Issue:**
When dvr is off, change the qna settings from the webcast app doesn't affect the Q&A plugin on the player.

**Fix:**
Add cuepoint code to cue point list also in dvr off mode.

Solves [SUP-43350](https://kaltura.atlassian.net/browse/SUP-43350)

[SUP-43350]: https://kaltura.atlassian.net/browse/SUP-43350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ