### PR TITLE
fix(FEC-14362): remove Summary cuepoint type

### DIFF
--- a/src/providers/vod/vod-provider.ts
+++ b/src/providers/vod/vod-provider.ts
@@ -44,7 +44,7 @@ export class VodProvider extends Provider {
       thumbSubTypesFilter = `${KalturaThumbCuePointSubType.SLIDE},`;
     }
 
-    if (this._types.has(KalturaCuePointType.CHAPTER) && !this._types.has(KalturaCuePointType.SUMMARY)) {
+    if (this._types.has(KalturaCuePointType.CHAPTER)) {
       thumbSubTypesFilter += `${KalturaThumbCuePointSubType.CHAPTER},`;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,7 @@ export enum KalturaCuePointType {
   VIEW_CHANGE = 'viewchange',
   CHAPTER = 'chapter',
   HOTSPOT = 'hotspot',
-  CAPTION = 'caption',
-  SUMMARY = 'summary'
+  CAPTION = 'caption'
 }
 
 export enum CuePointTags {


### PR DESCRIPTION
**the issue:**
when playkit-unisphere plugin loads summary & chapters widget, but the chapters data is empty, "regular" chapters should be shown on timeline (if exist).

**root cause:**
when fetching VOD data, we exclude Chapter cuepoints from the request in case Summary cuepoint was registered.

**solution:**
- remove Summary cuepoint type
- do not exclude Chapter cuepoints from the filter request

Resolves FEC-14362