### PR TITLE
fix(SUP-44789): The HOTSPOT in Simulive disappeared after one min of streaming

### DIFF
--- a/src/providers/live/live-provider.ts
+++ b/src/providers/live/live-provider.ts
@@ -95,7 +95,7 @@ export class LiveProvider extends Provider {
         }
 
         const [partType, originalEntryId, clipStartTimestamp] = id3Data.clipId.split('-');
-        const cuepointOffset = this._getSimuliveCuepointOffset(id3Data.setId, id3Data.clipId);
+        const cuepointOffset = this._getSimuliveCuepointOffset(id3Data.clipId);
         if (cuepointOffset === null) {
           return;
         }
@@ -380,7 +380,7 @@ export class LiveProvider extends Provider {
     }
   }
 
-  private _getSimuliveCuepointOffset(setId: string, clipId: string): number | null {
+  private _getSimuliveCuepointOffset(clipId: string): number | null {
     const [_, __, clipStartTimestamp] = clipId.split('-');
     if (!clipStartTimestamp || this._simuliveStartTime === -1) return null;
     return (Number(clipStartTimestamp) - this._simuliveStartTime) / 1000;

--- a/src/providers/live/live-provider.ts
+++ b/src/providers/live/live-provider.ts
@@ -37,7 +37,11 @@ export class LiveProvider extends Provider {
   private _thumbUrlIsLoaderActive = false;
   private _thumbUrlAssetIdQueue: Array<string> = [];
 
-  private _simuliveClipTimestamps: Set<string>;
+  private _simuliveEntryIds: Set<string>;
+
+  private _simuliveStartTime = -1;
+
+  private _currentClipEntryId?: string;
 
   constructor(player: Player, eventManager: EventManager, logger: Logger, types: CuepointTypeMap) {
     super(player, eventManager, logger, types);
@@ -48,7 +52,16 @@ export class LiveProvider extends Provider {
     this._constructPushNotificationListener();
     this._pushNotification.registerToPushServer(this._player.sources.id, types, this._handleConnection, this._handleConnectionError);
     this._addBindings();
-    this._simuliveClipTimestamps = new Set();
+    this._simuliveEntryIds = new Set();
+
+    this._eventManager.listen(this._player, this._player.Event.PLAYING, () => {
+      if (this._simuliveStartTime === -1) {
+        this._simuliveStartTime = Date.now() - this._player.currentTime;
+      }
+    });
+    this._eventManager.listen(this._player, this._player.Event.RESET, () => {
+      this._simuliveStartTime = -1;
+    });
   }
 
   private _makeCurrentTimeLiveReadyPromise = () => {
@@ -82,34 +95,28 @@ export class LiveProvider extends Provider {
         }
 
         const [partType, originalEntryId, clipStartTimestamp] = id3Data.clipId.split('-');
-        const cuepointOffset = this._getSimuliveCuepointOffset(
-          id3Data.timestamp,
-          id3Data.setId,
-          id3Data.clipId,
-          id3TagCues[id3TagCues.length - 1].startTime
-        );
+        const cuepointOffset = this._getSimuliveCuepointOffset(id3Data.setId, id3Data.clipId);
         if (cuepointOffset === null) {
           return;
         }
 
+        const currentClipStartTime = this._player.currentTime + cuepointOffset;
+
         const textTracks = [...(this._player.getVideoElement().textTracks as any)];
         const cuepointsTrack = textTracks.find(t => t.label === 'CuePoints');
-        const activeCues = cuepointsTrack?.activeCues;
+        const activeCues = cuepointsTrack?.activeCues || [];
 
-        if (activeCues) {
+        if (originalEntryId !== this._currentClipEntryId) {
+          this._currentClipEntryId = originalEntryId;
+
           for (const cue of activeCues) {
-            // @ts-ignore
-            const nextClipStartTime = this._player.getStartTimeOfDvrWindow() + cuepointOffset;
-
-            if (cue.startTime < nextClipStartTime && cue.endTime > nextClipStartTime) {
-              cue.endTime = nextClipStartTime;
-            }
+            cue.endTime = currentClipStartTime;
           }
-        }
 
-        if (!this._simuliveClipTimestamps.has(clipStartTimestamp)) {
-          this._simuliveClipTimestamps.add(clipStartTimestamp);
-          this._addSimuliveCuepoints(originalEntryId, cuepointOffset);
+          if (!this._simuliveEntryIds.has(originalEntryId)) {
+            this._simuliveEntryIds.add(originalEntryId);
+            this._addSimuliveCuepoints(originalEntryId, currentClipStartTime);
+          }
         }
       } catch (e) {
         this._logger.debug('Failed retrieving id3 tag metadata');
@@ -373,21 +380,10 @@ export class LiveProvider extends Provider {
     }
   }
 
-  private _getSimuliveCuepointOffset(timestamp: string, setId: string, clipId: string, cueStartTime: number): number | null {
-    const setIdData = setId.split(',').reduce((result: any, currValue: string) => {
-      const [key, value] = currValue.split('=');
-      return {
-        ...result,
-        [key]: value
-      };
-    }, {});
-
-    const [partType, originalEntryId, clipStartTimestamp] = clipId.split('-');
-    if (!clipStartTimestamp || setIdData.offset === undefined) return null;
-
-    const firstClipStartTimestamp = +timestamp - +setIdData.offset - cueStartTime * 1000;
-    // @ts-ignore
-    return this._player.getStartTimeOfDvrWindow() + (clipStartTimestamp - firstClipStartTimestamp) / 1000;
+  private _getSimuliveCuepointOffset(setId: string, clipId: string): number | null {
+    const [_, __, clipStartTimestamp] = clipId.split('-');
+    if (!clipStartTimestamp || this._simuliveStartTime === -1) return null;
+    return (Number(clipStartTimestamp) - this._simuliveStartTime) / 1000;
   }
 
   private _addSimuliveCuepoints(originalEntryId: string, cuepointOffset: number) {

--- a/test/src/providers/live/live-provider.spec.js
+++ b/test/src/providers/live/live-provider.spec.js
@@ -50,7 +50,7 @@ describe('Check Live provider', () => {
     });
 
     it('should check event listener bindings', () => {
-      expect(liveProvider._eventManager._bindingMap._map.size).to.eq(3);
+      expect(liveProvider._eventManager._bindingMap._map.size).to.eq(5);
     });
 
     it('should handle timed metadata', () => {


### PR DESCRIPTION
When we want to decide where to position hotspot / thumbnail cues in the simulive, we need to figure out the offset of

_**Absolute start time of current clip - Absolute start time of the simulive** (we calculate the last value from the absolute start time of the earliest clip that we have encountered)_

Which is the SERVER SIDE relative distance between the start time of the simulive and the start of the current clip.

We then add this value to the start of the dvr window, which is the relative CLIENT SIDE start time of the stream as the player knows it, and append this value to every cue. Now, the cues are positioned relative to the start of the stream, again as the player knows it.

However, when there is no dvr window in the simulive (like in EP), the value of getStartTimeOfDvrWindow gets reset either after something like 30-60s, or even sooner if you refresh the page - this breaks the calculation, because we no longer know what is the relative start time of the stream. Also, refreshing the page or joining late means we are now missing the id3 data of the first clip that we might have had saved, so we no longer know what is the stream absolute start time.

* * *

To account for this "unreliable" dvr window, we change the calculation of the offset to:

_**Absolute start time of current clip - (Absolute time when player started playing - value of currentTime when player started playing** (=The absolute time at currentTime 0))_

We then apply this offset to the CURRENT TIME instead of the dvr window "start time", To get the value of currentTime at the start of the current clip (we cant actually seek to it, because there's no dvr, but we can use it for positioning). This is our new cuepoint offset for the current clip.

* * *

Following this change:
- The cues now no longer **disappear** within a minute
- The cues still **appear** and **disappear** too soon (which might be good enough)

![image](https://github.com/user-attachments/assets/7c7e9fd1-5e0c-48f4-96be-13e1b2cee4f2)

Explanation - because the stream doesn't actually start when scheduled - it starts like 18s later - the server id3's send the current clip start time as X, but it's actually X + 18s+, so if we use a server value and a client value instead of two server values in the calculation (plus i guess the time diff between PLAY to PLAYING events), the offset calculation now has around 20-40s of an error margin.

I wasn't sure if i should add some kind of magic number X + 20 to the calculation or not, as the exact diff number is variable.