### PR TITLE
fix(FEC:14736): Remove access to window.KalturaPlayer from plugns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {Cuepoints} from './cuepoints';
+import {registerPlugin} from '@playkit-js/kaltura-player-js';
 
 declare var __VERSION__: string;
 declare var __NAME__: string;
@@ -10,4 +11,4 @@ export {Cuepoints as Plugin};
 export {VERSION, NAME};
 
 const pluginName: string = 'kalturaCuepoints';
-KalturaPlayer.core.registerPlugin(pluginName, Cuepoints);
+registerPlugin(pluginName, Cuepoints as any);


### PR DESCRIPTION
use registerPlugin function from kaltura-player-js and not from window.KalturaPlayer

solves [FEC-14736](https://kaltura.atlassian.net/browse/FEC-14736)

[FEC-14736]: https://kaltura.atlassian.net/browse/FEC-14736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ